### PR TITLE
フェードイン・フェードアウトを修正

### DIFF
--- a/EngineLayers/ApplicationLayer/Object/2D/Wireframe/Wireframe.cpp
+++ b/EngineLayers/ApplicationLayer/Object/2D/Wireframe/Wireframe.cpp
@@ -226,6 +226,50 @@ void Wireframe::DrawBox(const Vector3& position, const Vector3& size, const Vect
 	boxVertexIndex_ += kBoxVertexCount;
 }
 
+void Wireframe::DrawBox(const Vector3& position, const Vector3& size, const Vector4& color, float rotationAngle, const Vector3& rotationAxis)
+{
+	// 回転行列を作成
+	Matrix4x4 rotationMatrix = Matrix4x4::MakeRotateMatrix(Vector3::Multiply(rotationAngle, rotationAxis));
+
+	// 四角形の頂点座標（中心を原点として）
+	Vector3 vertices[4] = {
+		Vector3(-size.x * 0.5f, -size.y * 0.5f, 0.0f),  // 左下
+		Vector3(size.x * 0.5f, -size.y * 0.5f, 0.0f),   // 右下
+		Vector3(size.x * 0.5f, size.y * 0.5f, 0.0f),    // 右上
+		Vector3(-size.x * 0.5f, size.y * 0.5f, 0.0f)    // 左上
+	};
+
+	// 回転を適用して位置にオフセット
+	for (int i = 0; i < 4; i++) {
+		vertices[i] = Vector3::Transform(vertices[i], rotationMatrix);
+		vertices[i] = vertices[i] + position;
+	}
+
+	// 頂点データの設定
+	boxData_->vertexData[boxVertexIndex_ + 0].position = vertices[0];
+	boxData_->vertexData[boxVertexIndex_ + 1].position = vertices[1];
+	boxData_->vertexData[boxVertexIndex_ + 2].position = vertices[2];
+	boxData_->vertexData[boxVertexIndex_ + 3].position = vertices[3];
+
+	// カラーデータの設定
+	boxData_->vertexData[boxVertexIndex_ + 0].color = color;
+	boxData_->vertexData[boxVertexIndex_ + 1].color = color;
+	boxData_->vertexData[boxVertexIndex_ + 2].color = color;
+	boxData_->vertexData[boxVertexIndex_ + 3].color = color;
+
+	// インデックスデータの設定
+	boxData_->indexData[boxIndex_] = boxVertexIndex_ + 0;
+	boxData_->indexData[boxIndex_ + 1] = boxVertexIndex_ + 1;
+	boxData_->indexData[boxIndex_ + 2] = boxVertexIndex_ + 2;
+	boxData_->indexData[boxIndex_ + 3] = boxVertexIndex_ + 0;
+	boxData_->indexData[boxIndex_ + 4] = boxVertexIndex_ + 2;
+	boxData_->indexData[boxIndex_ + 5] = boxVertexIndex_ + 3;
+
+	// インデックスと頂点インデックスの更新
+	boxIndex_ += kBoxIndexCount;
+	boxVertexIndex_ += kBoxVertexCount;
+}
+
 
 /// -------------------------------------------------------------
 ///				　	      AABBを描画する処理
@@ -1307,7 +1351,7 @@ void Wireframe::CreateBoxVertexData(BoxData* boxData)
 {
 	UINT vertexBufferSize = sizeof(VertexData) * kBoxVertexCount * kBoxMaxCount;
 	UINT indexBufferSize = sizeof(uint32_t) * kBoxIndexCount * kBoxMaxCount;
-	
+
 	// 頂点リソースを生成
 	boxData->vertexBuffer = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), vertexBufferSize);
 

--- a/EngineLayers/ApplicationLayer/Object/2D/Wireframe/Wireframe.h
+++ b/EngineLayers/ApplicationLayer/Object/2D/Wireframe/Wireframe.h
@@ -107,7 +107,11 @@ public: /// ---------- 2D用の線の描画 ---------- ///
 	// 三角形を描画
 	void DrawTriangle(const Vector3& position1, const Vector3& position2, const Vector3& position3, const Vector4& color);
 
+	// 四角形を描画
 	void DrawBox(const Vector3& position, const Vector3& size, const Vector4& color);
+
+	// 四角形を描画（回転軸を持たせた）
+	void DrawBox(const Vector3& position, const Vector3& size, const Vector4& color, float rotationAngle, const Vector3& rotationAxis = { 0.0f, 0.0f, 1.0f });
 
 	// 五芒星（ペンタグラム）を描画
 	void DrawPentagram(const Vector3& center, float radius, const Vector4& color);

--- a/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/FadeManager.cpp
+++ b/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/FadeManager.cpp
@@ -1,6 +1,8 @@
 #include "FadeManager.h"
 #include <LogString.h>
 #include "Wireframe.h"
+#include "Camera.h"
+#include "Object3DCommon.h"
 #include <WinApp.h>
 
 
@@ -19,6 +21,8 @@ FadeManager* FadeManager::GetInstance()
 /// -------------------------------------------------------------
 void FadeManager::Initialize()
 {
+	camera_ = Object3DCommon::GetInstance()->GetDefaultCamera();
+	object3DCommon_ = Object3DCommon::GetInstance();
 	fadeState_ = FadeState::None;
 	alpha_ = 0.0f;
 }
@@ -58,7 +62,12 @@ void FadeManager::Draw()
 	if (fadeState_ == FadeState::None) return; // 状態がNoneなら描画しない
 
 	// ワイヤーフレームでフェードの可視化
-	Wireframe::GetInstance()->DrawBox({ -200.0f, -200.0f, 0.0f }, { WinApp::kClientWidth,WinApp::kClientHeight,0.0f }, { fadeColor_.x,fadeColor_.y,fadeColor_.z,alpha_ });
+	Vector3 pos(0.0f, 0.0f, 0.0f);
+	Vector3 size(50.0f, 30.0f, 0.0f);
+	float angle = 70.0f * (3.14159f / 180.0f); // 度からラジアンに変換
+
+	// ワイヤーフレームの描画
+	Wireframe::GetInstance()->DrawBox(pos, size, { fadeColor_.x,fadeColor_.y,fadeColor_.z,alpha_ }, angle, camera_->GetRotate());
 }
 
 void FadeManager::StartFadeIn(float speed, const Vector4& color)

--- a/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/FadeManager.h
+++ b/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/FadeManager.h
@@ -2,6 +2,11 @@
 #include "Vector4.h"
 
 
+/// ---------- 前方宣言 ---------- ///
+class Camera;
+class Object3DCommon;
+
+
 /// -------------------------------------------------------------
 ///			　フェード・イン・アウトを管理するクラス
 /// -------------------------------------------------------------
@@ -44,6 +49,10 @@ public: /// ---------- メンバ関数 ---------- ///
 private: /// ---------- メンバ変数 ---------- ///
 
 	FadeState fadeState_ = FadeState::None;
+
+	Camera* camera_ = nullptr;
+
+	Object3DCommon* object3DCommon_ = nullptr;
 
 	float alpha_ = 0.0f;
 	float fadeSpeed_ = 1.0f;

--- a/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/GameOverScene/GameOverScene.cpp
+++ b/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/GameOverScene/GameOverScene.cpp
@@ -7,17 +7,89 @@
 #include <SpriteManager.h>
 #include <Object3DCommon.h>
 #include <SkyBoxManager.h>
+#include "SceneManager.h"
+#include "FadeManager.h"
+
 
 void GameOverScene::Initialize()
 {
+	FadeManager::GetInstance()->StartFadeOut();
+
 	dxCommon_ = DirectXCommon::GetInstance();
 	textureManager = TextureManager::GetInstance();
 	input = Input::GetInstance();
 	wavLoader_ = std::make_unique<WavLoader>();
+
+	// テクスチャのパスをリストで管理
+	texturePaths_ = {
+		"Resources/monsterBall.png",
+		//"Resources/uvChecker.png",
+	};
+
+	/// ---------- TextureManagerの初期化 ----------///
+	for (auto& texture : texturePaths_)
+	{
+		textureManager->LoadTexture(texture);
+	}
+
+	/// ---------- Spriteの初期化 ---------- ///
+	for (uint32_t i = 0; i < 1; i++)
+	{
+		sprites_.push_back(std::make_unique<Sprite>());
+
+		// テクスチャの範囲をチェック
+		if (!texturePaths_.empty())
+		{
+			sprites_[i]->Initialize(texturePaths_[i % texturePaths_.size()]);
+		}
+		else
+		{
+			throw std::runtime_error("Texture paths list is empty!");
+		}
+
+		sprites_[i]->SetPosition(Vector2(100.0f * i, 100.0f * i));
+	}
 }
 
 void GameOverScene::Update()
 {
+	// 入力によるシーン切り替え
+	if (input->TriggerKey(DIK_RETURN) || input->TriggerButton(XButtons.A)) // Enterキーが押されたら
+	{
+		if (sceneManager_)
+		{
+			sceneManager_->ChangeScene("TitleScene"); // シーン名を指定して変更
+		}
+
+		wavLoader_->StopBGM();
+	}
+
+	if (input->TriggerKey(DIK_F1))
+	{
+		if (sceneManager_)
+		{
+			sceneManager_->ChangeScene("TuboScene");
+		}
+	}
+
+	if (input->TriggerKey(DIK_F2))
+	{
+		if (sceneManager_)
+		{
+			sceneManager_->ChangeScene("AkimotoScene");
+		}
+	}
+
+	if (input->TriggerKey(DIK_F3))
+	{
+
+	}
+
+	// スプライトの更新処理
+	for (auto& sprite : sprites_)
+	{
+		sprite->Update();
+	}
 }
 
 void GameOverScene::Draw()
@@ -33,7 +105,11 @@ void GameOverScene::Draw()
 	/// ---------------------------------------- ///
 	// スプライトの共通描画設定
 	SpriteManager::GetInstance()->SetRenderSetting();
-
+	// スプライトの更新処理
+	for (auto& sprite : sprites_)
+	{
+		sprite->Draw();
+	}
 
 	/// ---------------------------------------- ///
 	/// ---------- オブジェクト3D描画 ---------- ///

--- a/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/GamePlayScene/GamePlayScene.cpp
+++ b/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/GamePlayScene/GamePlayScene.cpp
@@ -24,6 +24,7 @@ using namespace Easing;
 ///				　			　初期化処理
 /// -------------------------------------------------------------
 void GamePlayScene::Initialize() {
+	// フェードアウト開始
 	FadeManager::GetInstance()->StartFadeOut();
 
 #ifdef _DEBUG
@@ -38,10 +39,6 @@ void GamePlayScene::Initialize() {
 
 	camera_ = Object3DCommon::GetInstance()->GetDefaultCamera();
 
-	/// ---------- サウンドの初期化 ---------- ///
-	wavLoader_ = std::make_unique<WavLoader>();
-	wavLoader_->StreamAudioAsync("Get-Ready.wav", 0.1f, 1.0f, false);
-
 	field_ = std::make_unique<Field>();
 	field_->Initialize();
 	field_->SetScale(fieldScale_);
@@ -49,7 +46,7 @@ void GamePlayScene::Initialize() {
 	// Playerクラスの初期化
 	player_ = std::make_unique<Player>();
 	player_->Initialize();
-	player_->SetPosition({1000.0f, 1000.0f, 1000.0f});
+	player_->SetPosition({ 1000.0f, 1000.0f, 1000.0f });
 
 	// PlayerUIの初期化
 	playerUI_ = std::make_unique<PlayerUI>();
@@ -99,10 +96,7 @@ void GamePlayScene::Update() {
 	}
 #endif // _DEBUG
 
-	if (FadeManager::GetInstance()->IsFadeComplete()) {
-		camera_->SetRotate({1.57f, 0.0f, 0.0f});
-		camera_->SetTranslate(cameraPosition_);
-	}
+	camera_->SetTranslate(cameraPosition_);
 
 	// シーン切り替え
 	if (input_->TriggerKey(DIK_F1)) {
@@ -164,7 +158,7 @@ void GamePlayScene::Update() {
 
 	playerUI_->SetHp(player_->GetHp());
 	playerUI_->Update();
-	
+
 	// 武器の更新処理
 	weapon_->SetPlayerPosition(player_->GetPosition());
 	weapon_->SetPlayerRotation(player_->GetRotation());
@@ -325,12 +319,13 @@ void GamePlayScene::CameraShake() {
 			input_->StopVibration();
 			isCameraShaking_ = false;
 			camera_->SetTranslate(cameraPosition_); // 元の位置に戻す
-		} else {
+		}
+		else {
 			// ランダムな揺れを生成
 			std::random_device rd;
 			std::mt19937 gen(rd());
 			std::uniform_real_distribution<float> dis(-shakeMagnitude_, shakeMagnitude_);
-			Vector3 shakeOffset = {dis(gen), dis(gen), dis(gen)};
+			Vector3 shakeOffset = { dis(gen), dis(gen), dis(gen) };
 			camera_->SetTranslate(cameraPosition_ + shakeOffset);
 			// コントローラーを振動させる
 			input_->SetVibration(1, 1);
@@ -355,8 +350,9 @@ void GamePlayScene::GameStart() {
 			startTimer_ = maxStartT_;
 			isStartEasing_ = false;
 			isPlayerPositionSet_ = true;
-			
-		} else {
+
+		}
+		else {
 			startTimer_ += 0.5f;
 		}
 		// ポヨンポヨンしてフィールドが広がる演出
@@ -366,16 +362,17 @@ void GamePlayScene::GameStart() {
 	// プレイヤーの位置がセットされたか
 	if (isPlayerPositionSet_) {
 		// プレイヤーの位置をセット
-		player_->SetPosition({8.0f, 20.0f, 8.0f});
+		player_->SetPosition({ 8.0f, 20.0f, 8.0f });
 		if (playerStartTimer_ >= maxPlayerStartT_) {
 			playerStartTimer_ = maxPlayerStartT_;
 			isPlayerPositionSet_ = false;
 			isGameStart_ = true;
-		} else {
+		}
+		else {
 			playerStartTimer_ += 0.5f;
 			// 上からプレイヤーが登場する
-			player_->SetPosition(Vector3::Lerp({8.0f, 20.0f, 8.0f}, {8.0f, 0.0f, 8.0f}, easeOutBounce(playerStartTimer_ / maxPlayerStartT_)));
+			player_->SetPosition(Vector3::Lerp({ 8.0f, 20.0f, 8.0f }, { 8.0f, 0.0f, 8.0f }, easeOutBounce(playerStartTimer_ / maxPlayerStartT_)));
 		}
-		
+
 	}
 }

--- a/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/TitleScene/TitleScene.cpp
+++ b/EngineLayers/ApplicationLayer/SceneManagement/LogicLayer/TitleScene/TitleScene.cpp
@@ -13,6 +13,9 @@
 /// -------------------------------------------------------------
 void TitleScene::Initialize()
 {
+	// フェードアウト開始
+	FadeManager::GetInstance()->StartFadeOut();
+
 	dxCommon_ = DirectXCommon::GetInstance();
 	textureManager = TextureManager::GetInstance();
 	input = Input::GetInstance();
@@ -47,11 +50,6 @@ void TitleScene::Initialize()
 
 		sprites_[i]->SetPosition(Vector2(100.0f * i, 100.0f * i));
 	}
-
-	/// ---------- サウンドの初期化 ---------- ///
-	wavLoader_->StreamAudioAsync("RPGBattle01.wav", 0.2f, 1.0f, false);
-
-	FadeManager::GetInstance()->StartFadeOut();
 }
 
 
@@ -61,7 +59,7 @@ void TitleScene::Initialize()
 void TitleScene::Update()
 {
 	// 入力によるシーン切り替え
-	if (input->TriggerKey(DIK_RETURN)) // Enterキーが押されたら
+	if (input->TriggerKey(DIK_RETURN) || input->TriggerButton(XButtons.A)) // Enterキーが押されたら
 	{
 		if (sceneManager_)
 		{

--- a/EngineLayers/FrameworkLayer/Framework/Framework.cpp
+++ b/EngineLayers/FrameworkLayer/Framework/Framework.cpp
@@ -52,13 +52,13 @@ void Framework::Initialize()
 	// DirectX共通クラスの生成
 	dxCommon_ = DirectXCommon::GetInstance();
 	dxCommon_->Initialize(winApp_, WinApp::kClientWidth, WinApp::kClientHeight);
-	
+
 	// SRVマネージャーの生成
 	SRVManager::GetInstance()->Initialize(dxCommon_);
 
 	// テクスチャマネージャーの生成
 	TextureManager::GetInstance()->Initialize(dxCommon_);
-	
+
 	// スプライトマネージャの初期化
 	SpriteManager::GetInstance()->Initialize(dxCommon_);
 
@@ -70,9 +70,9 @@ void Framework::Initialize()
 
 	// デフォルトカメラの生成と初期化
 	defaultCamera_ = std::make_unique<Camera>();
-	defaultCamera_->SetRotate({ 0.3f,0.0f,0.0f });
-	defaultCamera_->SetTranslate({ 0.0f,15.0f,-50.0f });
-	
+	defaultCamera_->SetRotate({ 1.57f,0.0f,0.0f });
+	defaultCamera_->SetTranslate({ 0.0f,50.0f, 0.0f });
+
 	// デフォルトカメラの設定
 	Object3DCommon::GetInstance()->SetDefaultCamera(defaultCamera_.get());
 
@@ -81,7 +81,7 @@ void Framework::Initialize()
 
 	// ワイヤーフレームのカメラ設定
 	Wireframe::GetInstance()->SetCamera(defaultCamera_.get());
-	
+
 	// ワイヤーフレームの初期化処理
 	Wireframe::GetInstance()->Initialize(dxCommon_);
 


### PR DESCRIPTION
ワイヤーフレームのDrawBoxに回転軸を追加
ゲームオーバーシーンにフェードとスプライトを追加
タイトルシーンにフェードを追加
フレームワークにカメラの角度と座標を変更
フェードマネージャの描画処理を回転を追加したDrawBox関数に変更
ゲームプレイシーンにカメラを回転させていたSetRotationを削除
音楽を削除

今後の改善策
・プレイヤーのHPが0になった時、GameOverSceneに飛ぶ処理を書いてみたがシーンが作られない