### PR TITLE
出力ファイル名の変更とdxil.dllのコピー追加

### DIFF
--- a/CG2_DirectXGame.vcxproj
+++ b/CG2_DirectXGame.vcxproj
@@ -104,7 +104,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(ProjectDir)Externals\assimp\lib\Release\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>assimp-vc143-mt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)3126_張爪$(TargetExt)</OutputFile>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxcompiler.dll" "$(TargetDir)dxcompiler.dll"


### PR DESCRIPTION
出力ファイル名を固定の`3126_張爪`から、ターゲット名に基づく動的な名前`$(TargetName)`に変更しました。また、`PostBuildEvent`内に`dxil.dll`のコピーコマンドを追加しました。