### PR TITLE
チュートリアル終了時のUI処理を修正

### DIFF
--- a/ApplicationLayer/Scene/TutorialScene/TutorialScene.cpp
+++ b/ApplicationLayer/Scene/TutorialScene/TutorialScene.cpp
@@ -901,11 +901,11 @@ void TutorialScene::TutorialEndUpdate() {
 
 	// Aボタンが離されたらフラグを立てる
 	if (!Input::GetInstance()->PushButton(0)) {
-		isSEEnabled_ = true; // SEを有効にする
 		isAButtonReleased_ = true;
 	}
 	// フラグが立っていて、Aボタンが押されたら処理を通す
 	if (isAButtonReleased_ && Input::GetInstance()->PushButton(0)) {
+		isSEEnabled_ = true; // SEを有効にする
 		tutorialUI_->TutorialEndUIDisappear();
 		tutorialUI_->DecisionUIDisappear(); // 決定UIを非表示にする
 		isAButtonReleased_ = false; // もう一度押すまで処理を通さない


### PR DESCRIPTION
`TutorialEndUpdate` 関数内で、Aボタンが離されたときに効果音を有効にする処理を移動し、Aボタンが押された際にチュートリアルUIを非表示にする処理を追加しました。これにより、UIの表示制御が改善されました。