### PR TITLE
衝突ワールドの初期化と更新機能を追加

### DIFF
--- a/ApplicationLayer/Colliders/CollisionWorld.cpp
+++ b/ApplicationLayer/Colliders/CollisionWorld.cpp
@@ -1,0 +1,46 @@
+#include "CollisionWorld.h"
+#include "CollisionManager.h"
+#include "Player.h"
+#include "Enemy.h"
+#include "Hook.h"
+#include "Weapon.h"
+#include "EnemyBullet.h"
+
+
+/// -------------------------------------------------------------
+///				　		衝突ワールドの初期化
+/// -------------------------------------------------------------
+void CollisionWorld::Initialize(CollisionManager* collisionManager, const CollisionObjects& objects)
+{
+	collisionManager_ = collisionManager; // 衝突マネージャへのポインタをセット
+	objects_ = objects; // 衝突オブジェクトの構造体をセット
+}
+
+
+/// -------------------------------------------------------------
+///				　		衝突ワールドの更新
+/// -------------------------------------------------------------
+void CollisionWorld::Update()
+{
+	collisionManager_->Reset(); // 衝突マネージャのリセット
+
+	if (!objects_.player || !objects_.enemy) return; // プレイヤーまたは敵が存在しない場合は更新しない
+	if (objects_.player->GetHp() <= 0 || objects_.enemy->GetHp() <= 0) return; // プレイヤーまたは敵が死亡している場合は更新しない
+
+	collisionManager_->AddCollider(objects_.player); // プレイヤーのコライダーを追加
+	if (objects_.player->GetIsAttack())
+		collisionManager_->AddCollider(objects_.weapon); // プレイヤーが攻撃中なら武器のコライダーを追加
+
+	collisionManager_->AddCollider(objects_.hook); // フックのコライダーを追加
+	collisionManager_->AddCollider(objects_.enemy); // 敵のコライダーを追加
+
+	for (const auto& bullet : *objects_.enemyBullets) {
+		collisionManager_->AddCollider(bullet.get()); // 敵の弾のコライダーを追加
+	}
+
+	// 全衝突判定の判定と応答を行う
+	collisionManager_->CheckAllCollisions();
+
+	// 衝突判定の更新
+	collisionManager_->Update(); // 衝突マネージャの更新
+}

--- a/ApplicationLayer/Colliders/CollisionWorld.h
+++ b/ApplicationLayer/Colliders/CollisionWorld.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <list>
+#include <memory>
+
+/// ---------- 前方宣言 ---------- ///
+class CollisionManager;
+class Player;
+class Enemy;
+class Hook;
+class Weapon;
+class EnemyBullet;
+
+/// ---------- 衝突オブジェクトの構造体 ---------- ///
+struct CollisionObjects
+{
+	Player* player = nullptr;          // プレイヤー
+	Weapon* weapon = nullptr;          // 武器
+	Hook* hook = nullptr;              // フック
+	Enemy* enemy = nullptr;            // 敵
+	std::list<std::unique_ptr<EnemyBullet>>* enemyBullets = nullptr; // 敵の弾
+};
+
+/// -------------------------------------------------------------
+///				　		衝突ワールドクラス
+/// -------------------------------------------------------------
+class CollisionWorld
+{
+public: /// ---------- メンバ関数 ---------- ///
+
+	// 衝突ワールドの初期化
+	void Initialize(CollisionManager* collisionManager, const CollisionObjects& objects);
+
+	// 衝突ワールドの更新
+	void Update();
+
+private: /// ---------- メンバ変数 ---------- ///
+
+	CollisionManager* collisionManager_ = nullptr; // 衝突マネージャへのポインタ
+	CollisionObjects objects_;                     // 衝突オブジェクトの構造体
+
+};
+

--- a/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -123,6 +123,11 @@ void GamePlayScene::Initialize()
 	// 衝突マネージャの生成
 	collisionManager_ = std::make_unique<CollisionManager>();
 	collisionManager_->Initialize();
+
+	// 衝突ワールドの生成
+	collisionWorld_ = std::make_unique<CollisionWorld>();
+	collisionWorld_->Initialize(collisionManager_.get(),
+		{ player_.get(), weapon_.get(), hook_.get(), enemy_.get(), enemyBullets_ });
 }
 
 
@@ -231,9 +236,8 @@ void GamePlayScene::Update()
 
 	sceneManager_->SetCameraShakeEnabled(sceneManager_->GetCameraShakeEnabled());
 
-	// 衝突マネージャの更新
-	collisionManager_->Update();
-	CheckAllCollisions();// 衝突判定と応答
+	// 衝突ワールドの更新
+	collisionWorld_->Update();
 
 	// フェードマネージャの更新（ここから下は書かない）
 	fadeManager_->Update();
@@ -413,50 +417,6 @@ void GamePlayScene::DrawImGui()
 
 }
 
-
-/// -------------------------------------------------------------
-///				　			衝突判定と応答
-/// -------------------------------------------------------------
-void GamePlayScene::CheckAllCollisions()
-{
-	// 衝突マネージャのリセット
-	collisionManager_->Reset();
-
-	// コライダーをリストに登録
-	collisionManager_->AddCollider(player_.get());
-
-	// 攻撃フラグを取得したらコライダーを追加
-	if (player_->GetIsAttack())
-	{
-		collisionManager_->AddCollider(weapon_.get());
-	}
-	collisionManager_->AddCollider(hook_.get());
-	collisionManager_->AddCollider(enemy_.get());
-
-	// 複数についてコライダーをリストに登録
-	for (const auto& bullet : *enemyBullets_)
-	{
-		collisionManager_->AddCollider(bullet.get());
-	}
-
-	// プレイヤーが死亡したらコライダーを削除または敵が死亡したらコライダーを削除
-	if (player_->GetHp() <= 0 || enemy_->GetHp() <= 0)
-	{
-		collisionManager_->RemoveCollider(player_.get());
-		collisionManager_->RemoveCollider(weapon_.get());
-		collisionManager_->RemoveCollider(hook_.get());
-		collisionManager_->RemoveCollider(enemy_.get());
-
-		// 複数についてコライダーを削除
-		for (const auto& bullet : *enemyBullets_)
-		{
-			collisionManager_->RemoveCollider(bullet.get());
-		}
-	}
-
-	// 衝突判定と応答
-	collisionManager_->CheckAllCollisions();
-}
 
 /// -------------------------------------------------------------
 ///				　		ゲームスタート初期化

--- a/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -7,6 +7,7 @@
 #include "AnimationManager.h"
 
 #include "CollisionManager.h"
+#include "CollisionWorld.h"
 #include "Player.h"
 #include "PlayerUI.h"
 #include "Enemy.h"
@@ -64,9 +65,6 @@ public: /// ---------- メンバ関数 ---------- ///
 
 private: /// ---------- メンバ関数 ---------- ///
 
-	// 衝突判定と応答
-	void CheckAllCollisions();
-
 	/*------カメラのシェイク------*/
 	void CameraShake();
 
@@ -113,6 +111,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	std::vector<std::unique_ptr<Sprite>> sprites_;
 	std::unique_ptr<CollisionManager> collisionManager_;
+	std::unique_ptr<CollisionWorld> collisionWorld_;
 
 	EffectManager* effectManager_;
 

--- a/CG2_DirectXGame.vcxproj
+++ b/CG2_DirectXGame.vcxproj
@@ -121,6 +121,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\EffectLayer\EffectManager.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\EnemyUI.cpp" />
     <ClCompile Include="BasePlayer.cpp" />
+    <ClCompile Include="ApplicationLayer\Colliders\CollisionWorld.cpp" />
     <ClCompile Include="EngineLayer\3D\SkyBox\SkyBox.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Enemy\AttackCommand.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Enemy\EnemyBullet.cpp" />
@@ -260,6 +261,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\EffectLayer\EffectManager.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\EnemyUI.h" />
     <ClInclude Include="BasePlayer.h" />
+    <ClInclude Include="ApplicationLayer\Colliders\CollisionWorld.h" />
     <ClInclude Include="EngineLayer\3D\SkyBox\SkyBox.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Enemy\AttackCommand.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Enemy\EnemyBullet.h" />

--- a/CG2_DirectXGame.vcxproj.filters
+++ b/CG2_DirectXGame.vcxproj.filters
@@ -302,6 +302,9 @@
       <Filter>EngineLayer\Base\DXLib\DX12SwapChain</Filter>
     </ClCompile>
     <ClCompile Include="BasePlayer.cpp" />
+    <ClCompile Include="ApplicationLayer\Colliders\CollisionWorld.cpp">
+      <Filter>ApplicationLayer\Colliders</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Externals\imgui\imconfig.h">
@@ -638,6 +641,9 @@
       <Filter>EngineLayer\Base\DXLib\DX12SwapChain</Filter>
     </ClInclude>
     <ClInclude Include="BasePlayer.h" />
+    <ClInclude Include="ApplicationLayer\Colliders\CollisionWorld.h">
+      <Filter>ApplicationLayer\Colliders</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Shaders\Object3d.hlsli">


### PR DESCRIPTION
`CollisionWorld` クラスを実装し、衝突オブジェクトの管理を行うメソッドを追加しました。
 `GamePlayScene` での衝突ワールドの生成と更新処理を統合し、従来の `CheckAllCollisions` メソッドを削除しました。 
プロジェクトファイルに新しいソースファイルを追加し、ビルドプロセスに組み込みました。